### PR TITLE
feat: Create webpage explaining MCP to a layman

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -10,6 +10,7 @@
     <p>This site is hosted using a simple Node.js server.</p>
     <nav>
         <a href="/index.html">Home</a>
+        <a href="/mcp.html">MCP Explained</a>
     </nav>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <p>This site displays a simple devotional greeting.</p>
     <nav>
         <a href="/about.html">About</a>
+        <a href="/mcp.html">MCP Explained</a>
     </nav>
 </body>
 </html>

--- a/public/mcp.html
+++ b/public/mcp.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MCP Explained</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Understanding the Modified Cahn-Hilliard-Navier-Stokes (MCP) Equations</h1>
+
+    <section>
+        <h2>What are the MCP Equations?</h2>
+        <p>Imagine mixing oil and water. They don't like to stay mixed, right? They separate. The MCP equations are a set of mathematical rules that describe how two or more fluids (like oil and water) move and separate over time. They are a combination of two powerful sets of equations:</p>
+        <ul>
+            <li><strong>The Navier-Stokes equations:</strong> These describe how fluids flow. Think of how water moves in a river or how air flows over a car.</li>
+            <li><strong>The Cahn-Hilliard equation:</strong> This describes the process of phase separation, like our oil and water example.</li>
+        </ul>
+        <p>By combining these, the MCP equations can predict the behavior of complex fluid mixtures.</p>
+    </section>
+
+    <section>
+        <h2>A Visual Analogy: A Crowded Room</h2>
+        <p>Think of a crowded room with two groups of people, say, fans of two different sports teams. Initially, they might be all mixed up. But over time, they will naturally form clusters with fans of their own team. The MCP equations are like the rules that govern how these clusters form and move around the room.</p>
+        <div id="svg-container">
+            <object type="image/svg+xml" data="phase_separation.svg">
+                Your browser does not support SVG
+            </object>
+        </div>
+    </section>
+
+    <section>
+        <h2>Why are they useful?</h2>
+        <p>The MCP equations are used in many fields, including:</p>
+        <ul>
+            <li><strong>Materials Science:</strong> To create new materials with specific properties.</li>
+            <li><strong>Biology:</strong> To understand how cells and tissues form.</li>
+            <li><strong>Engineering:</strong> To design better ways to mix or separate fluids.</li>
+        </ul>
+    </section>
+
+    <nav>
+        <a href="/index.html">Home</a>
+        <a href="/about.html">About</a>
+    </nav>
+</body>
+</html>

--- a/public/phase_separation.svg
+++ b/public/phase_separation.svg
@@ -1,0 +1,27 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+    <rect width="400" height="200" fill="#f0f0f0" />
+    <circle cx="50" cy="100" r="10" fill="blue" />
+    <circle cx="70" cy="80" r="10" fill="red" />
+    <circle cx="90" cy="120" r="10" fill="blue" />
+    <circle cx="110" cy="100" r="10" fill="red" />
+    <circle cx="130" cy="80" r="10" fill="blue" />
+    <circle cx="150" cy="120" r="10" fill="red" />
+
+    <circle cx="250" cy="50" r="10" fill="blue" />
+    <circle cx="270" cy="50" r="10" fill="blue" />
+    <circle cx="290" cy="50" r="10" fill="blue" />
+    <circle cx="250" cy="150" r="10" fill="red" />
+    <circle cx="270" cy="150" r="10" fill="red" />
+    <circle cx="290" cy="150" r="10" fill="red" />
+
+    <text x="50" y="20" font-family="Arial" font-size="16">Mixed State</text>
+    <text x="250" y="20" font-family="Arial" font-size="16">Separated State</text>
+    <path d="M 180 100 L 220 100" stroke="black" stroke-width="2" marker-end="url(#arrow)" />
+    <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+            markerWidth="6" markerHeight="6"
+            orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" />
+        </marker>
+    </defs>
+</svg>

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,5 @@
 body { font-family: Arial, sans-serif; margin: 2em; }
 h1 { color: #333; }
 nav a { margin-right: 1em; }
+section { margin-bottom: 1.5em; }
+#svg-container { text-align: center; margin: 2em 0; }


### PR DESCRIPTION
This commit introduces a new webpage that explains the Modified Cahn-Hilliard-Navier-Stokes (MCP) equations in simple terms for a non-technical audience.

The new page (`mcp.html`) includes:
- A simplified explanation of the MCP equations.
- An analogy to help understand the concept of phase separation.
- An SVG diagram to visually represent the concept.
- Navigation links from the home and about pages.
- Basic styling to match the rest of the site.